### PR TITLE
Add Flask backend, single‑page HTML frontend, and Railway deployment files for DiscograPY

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app --bind 0.0.0.0:$PORT

--- a/app.py
+++ b/app.py
@@ -1,0 +1,200 @@
+import os
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, redirect, render_template, request, session, url_for
+from flask_cors import CORS
+from spotipy.exceptions import SpotifyException
+
+from playlists import SpotifyDiscographyCreator, configure_logging
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "discograpy-dev-secret")
+CORS(app)
+
+
+def _json_error(message: str, status_code: int = 400):
+    return jsonify({"error": message}), status_code
+
+
+def _creator(dry_run: bool = False, verbose: bool = False) -> SpotifyDiscographyCreator:
+    logger = configure_logging(verbose=verbose)
+    return SpotifyDiscographyCreator(logger=logger, dry_run=dry_run)
+
+
+def _build_auth_payload(creator: SpotifyDiscographyCreator) -> Dict[str, Any]:
+    auth_manager = creator.sp.auth_manager
+    auth_url = auth_manager.get_authorize_url()
+    return {
+        "error": "Spotify authentication required.",
+        "auth_required": True,
+        "auth_url": auth_url,
+    }
+
+
+def _ensure_spotify_token(creator: SpotifyDiscographyCreator) -> Optional[Dict[str, Any]]:
+    auth_manager = creator.sp.auth_manager
+    token_info = auth_manager.get_cached_token()
+    if token_info:
+        return None
+    session["spotify_auth_requested"] = True
+    return _build_auth_payload(creator)
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(error: Exception):
+    app.logger.exception("Unhandled error: %s", error)
+    return _json_error("Internal server error", 500)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/callback")
+def callback():
+    code = request.args.get("code")
+    error = request.args.get("error")
+
+    if error:
+        return redirect(url_for("index", oauth_error=error))
+
+    if not code:
+        return redirect(url_for("index", oauth_error="missing_code"))
+
+    try:
+        creator = _creator()
+        auth_manager = creator.sp.auth_manager
+        auth_manager.get_access_token(code=code, check_cache=False)
+        session["spotify_auth_requested"] = False
+        return redirect(url_for("index", oauth_success="1"))
+    except Exception:
+        app.logger.exception("OAuth callback failed")
+        return redirect(url_for("index", oauth_error="callback_failed"))
+
+
+@app.get("/api/album-types")
+def album_types():
+    options = []
+    for idx, cfg in SpotifyDiscographyCreator.ALBUM_TYPE_CONFIGS.items():
+        options.append(
+            {
+                "index": idx,
+                "label": cfg["suffix"],
+                "description": cfg["description"],
+                "types": cfg["types"],
+            }
+        )
+    return jsonify(options)
+
+
+@app.post("/api/search")
+def search_artist():
+    data = request.get_json(silent=True) or {}
+    artist_name = (data.get("artist_name") or "").strip()
+
+    if not artist_name:
+        return _json_error("artist_name is required", 400)
+
+    try:
+        creator = _creator()
+        auth_response = _ensure_spotify_token(creator)
+        if auth_response:
+            return jsonify(auth_response), 401
+
+        artists = creator.search_artists(artist_name)
+        serialized = [
+            {
+                "id": artist.get("id"),
+                "name": artist.get("name"),
+                "followers": artist.get("followers", {}).get("total", 0),
+                "genres": artist.get("genres", [])[:3],
+            }
+            for artist in artists
+            if artist.get("id")
+        ]
+        return jsonify(serialized)
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    except EnvironmentError as exc:
+        return _json_error(str(exc), 500)
+    except SpotifyException as exc:
+        return _json_error(creator._spotify_error_message(exc), exc.http_status or 502)
+
+
+@app.post("/api/create")
+def create_playlist():
+    data = request.get_json(silent=True) or {}
+
+    artist_id = (data.get("artist_id") or "").strip()
+    artist_name = (data.get("artist_name") or "").strip()
+    album_type_selection = data.get("album_type_selection", 0)
+    dry_run = bool(data.get("dry_run", False))
+    verbose = bool(data.get("verbose", False))
+
+    if not artist_id or not artist_name:
+        return _json_error("artist_id and artist_name are required", 400)
+
+    if not isinstance(album_type_selection, int) or album_type_selection not in SpotifyDiscographyCreator.ALBUM_TYPE_CONFIGS:
+        return _json_error("album_type_selection must be an integer between 0 and 6", 400)
+
+    creator: Optional[SpotifyDiscographyCreator] = None
+    try:
+        creator = _creator(dry_run=dry_run, verbose=verbose)
+        auth_response = _ensure_spotify_token(creator)
+        if auth_response:
+            return jsonify(auth_response), 401
+
+        album_types = creator.get_album_types_from_selection(album_type_selection)
+        albums = creator._get_artist_albums(artist_id=artist_id, album_types=album_types)
+        filtered_albums, actual_types = creator.filter_albums_by_selection(albums, album_type_selection)
+
+        if not filtered_albums:
+            return _json_error("No albums found for selected filters", 404)
+
+        suffix = creator.get_playlist_suffix_from_selection(
+            album_type_selection,
+            actual_types if album_type_selection in (5, 6) else None,
+        )
+        playlist_name = f"{artist_name} discography {suffix}"
+
+        track_uris = creator._collect_tracks_from_albums(filtered_albums, verbose=verbose)
+        if not track_uris:
+            return _json_error("No tracks found for selected albums", 404)
+
+        playlist_id = None
+        playlist_url = None
+
+        if not dry_run:
+            playlist = creator._create_playlist(playlist_name, creator.PLAYLIST_DESCRIPTION)
+            playlist_id = playlist.get("id")
+            if playlist_id:
+                creator._add_tracks_to_playlist(playlist_id, track_uris)
+                playlist_url = f"https://open.spotify.com/playlist/{playlist_id}"
+
+        response = {
+            "artist": artist_name,
+            "playlist_name": playlist_name,
+            "playlist_id": playlist_id,
+            "playlist_url": playlist_url,
+            "albums_included": len(filtered_albums),
+            "tracks_added": len(track_uris),
+            "dry_run": dry_run,
+        }
+        return jsonify(response)
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    except EnvironmentError as exc:
+        return _json_error(str(exc), 500)
+    except SpotifyException as exc:
+        status = exc.http_status or 502
+        message = creator._spotify_error_message(exc) if creator else str(exc)
+        return _json_error(message, status)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "gunicorn app:app --bind 0.0.0.0:$PORT"
+healthcheckPath = "/"
+restartPolicyType = "on_failure"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-spotipy>=2.23.0
-python-dotenv>=1.0.0
+flask
+gunicorn
+spotipy
+python-dotenv
+flask-cors

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DiscograPY</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <style>
+      :root {
+        --accent: #39ff14;
+        --accent-2: #00e676;
+        --bg: #0a0a0a;
+        --card: #111111;
+        --text: #e0e0e0;
+        --error: #ff4d4d;
+        --border: rgba(57, 255, 20, 0.35);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; font-family: "Space Mono", monospace; background: var(--bg); color: var(--text);
+      }
+      .container { max-width: 920px; margin: 24px auto; padding: 20px; }
+      .card {
+        background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 20px; margin-bottom: 18px;
+        box-shadow: 0 0 10px rgba(57, 255, 20, 0.15);
+      }
+      .header { position: relative; }
+      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
+      .subtitle { margin: 0 0 16px; opacity: .85; }
+      .top-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+      .theme-toggle { position: absolute; top: 0; right: 0; }
+      button, .btn {
+        border: 1px solid var(--accent); background: transparent; color: var(--accent); padding: 10px 14px;
+        border-radius: 8px; cursor: pointer; font-family: inherit; text-decoration: none;
+        box-shadow: 0 0 10px rgba(57, 255, 20, 0.45);
+      }
+      button:disabled { opacity: .55; cursor: not-allowed; box-shadow: none; }
+      input, select {
+        width: 100%; margin-top: 8px; margin-bottom: 12px; border-radius: 8px; border: 1px solid var(--border);
+        padding: 10px; background: transparent; color: var(--text); font-family: inherit;
+      }
+      .artists-list { max-height: 250px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
+      .artist-item { border: 1px solid var(--border); border-radius: 8px; padding: 10px; cursor: pointer; }
+      .artist-item.selected { border-color: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.5); }
+      .hidden { display: none; }
+      .muted { opacity: .8; font-size: .9rem; }
+      .error { color: var(--error); margin-top: 8px; }
+      .spinner {
+        width: 28px; height: 28px; border: 3px solid rgba(57, 255, 20, 0.2); border-top-color: var(--accent);
+        border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 10px;
+      }
+      .loading { display: flex; align-items: center; margin-top: 10px; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      footer { text-align: center; margin: 20px 0 5px; }
+      footer a { color: var(--accent-2); }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <section class="card header">
+        <button id="themeToggle" class="theme-toggle">☾/☀</button>
+        <h1>DiscograPY</h1>
+        <p class="subtitle">Spotify Discography Playlist Creator</p>
+        <div class="top-actions">
+          <a class="btn" href="https://github.com/based-on-what/discograpy" target="_blank" rel="noopener noreferrer">⌁ Ver en GitHub</a>
+        </div>
+      </section>
+
+      <section class="card" id="step1">
+        <h2>Paso 1 — Buscar artista</h2>
+        <label for="artistInput">Nombre del artista</label>
+        <input id="artistInput" type="text" placeholder="Ej: Daft Punk" />
+        <button id="searchBtn">Buscar</button>
+        <div id="searchLoading" class="loading hidden"><div class="spinner"></div><span>Buscando artistas…</span></div>
+        <div id="searchError" class="error"></div>
+        <div id="authBox" class="hidden"></div>
+        <div id="artistsList" class="artists-list"></div>
+      </section>
+
+      <section class="card hidden" id="step2">
+        <h2>Paso 2 — Configurar playlist</h2>
+        <p>Artista seleccionado: <strong id="selectedArtist"></strong></p>
+        <label for="albumTypeSelect">Tipo de álbum</label>
+        <select id="albumTypeSelect"></select>
+        <label><input id="dryRun" type="checkbox" /> Dry run (solo vista previa — no se creará ninguna playlist)</label><br />
+        <label><input id="verbose" type="checkbox" /> Modo verbose</label><br /><br />
+        <button id="createBtn">Crear playlist</button>
+        <div id="createLoading" class="loading hidden"><div class="spinner"></div><span>Creando tu playlist de discografía…</span></div>
+        <div id="createError" class="error"></div>
+      </section>
+
+      <section class="card hidden" id="step3">
+        <h2>Paso 3 — Resultado</h2>
+        <p><strong>Artista:</strong> <span id="resArtist"></span></p>
+        <p><strong>Playlist:</strong> <span id="resPlaylist"></span></p>
+        <p><strong>Álbumes incluidos:</strong> <span id="resAlbums"></span></p>
+        <p><strong>Canciones añadidas:</strong> <span id="resTracks"></span></p>
+        <div id="playlistLinkWrap" class="hidden">
+          <a id="playlistLink" class="btn" href="#" target="_blank" rel="noopener noreferrer">Abrir playlist en Spotify</a>
+        </div>
+        <p id="dryRunNote" class="muted hidden">Dry run activo: no se creó ninguna playlist.</p>
+        <button id="resetBtn">Empezar de nuevo</button>
+      </section>
+
+      <footer>
+        Hecho con DiscograPY — código abierto ·
+        <a href="https://github.com/based-on-what/discograpy" target="_blank" rel="noopener noreferrer">GitHub</a>
+      </footer>
+    </div>
+
+    <script>
+      const state = { selectedArtist: null, albumTypes: [] };
+      const el = (id) => document.getElementById(id);
+
+      function applyTheme(mode) {
+        const dark = mode !== 'light';
+        const vars = dark
+          ? { '--bg': '#0a0a0a', '--card': '#111111', '--text': '#e0e0e0' }
+          : { '--bg': '#f0f0f0', '--card': '#ffffff', '--text': '#1a1a1a' };
+        Object.entries(vars).forEach(([k, v]) => document.documentElement.style.setProperty(k, v));
+      }
+
+      function initTheme() {
+        const stored = localStorage.getItem('discograpy-theme') || 'dark';
+        applyTheme(stored);
+        el('themeToggle').onclick = () => {
+          const current = localStorage.getItem('discograpy-theme') || 'dark';
+          const next = current === 'dark' ? 'light' : 'dark';
+          localStorage.setItem('discograpy-theme', next);
+          applyTheme(next);
+        };
+      }
+
+      async function request(path, payload) {
+        const res = await fetch(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          const err = new Error(data.error || 'Error inesperado');
+          err.data = data;
+          err.status = res.status;
+          throw err;
+        }
+        return data;
+      }
+
+      async function loadAlbumTypes() {
+        const res = await fetch('/api/album-types');
+        const data = await res.json();
+        state.albumTypes = data;
+        const select = el('albumTypeSelect');
+        select.innerHTML = '';
+        data.forEach((item) => {
+          const option = document.createElement('option');
+          option.value = item.index;
+          option.textContent = `${item.index} — ${item.label} (${item.description})`;
+          select.appendChild(option);
+        });
+      }
+
+      function renderArtists(artists) {
+        const list = el('artistsList');
+        list.innerHTML = '';
+        artists.forEach((artist) => {
+          const item = document.createElement('div');
+          item.className = 'artist-item';
+          item.innerHTML = `<strong>${artist.name}</strong><br><span class="muted">Seguidores: ${artist.followers.toLocaleString()} · Géneros: ${(artist.genres || []).join(', ') || 'n/a'}</span>`;
+          item.onclick = () => {
+            Array.from(document.querySelectorAll('.artist-item')).forEach((n) => n.classList.remove('selected'));
+            item.classList.add('selected');
+            state.selectedArtist = artist;
+            el('selectedArtist').textContent = artist.name;
+            el('step2').classList.remove('hidden');
+            el('createError').textContent = '';
+          };
+          list.appendChild(item);
+        });
+      }
+
+      function showAuth(authUrl) {
+        el('authBox').classList.remove('hidden');
+        el('authBox').innerHTML = `<p class="error">Debes autenticarte con Spotify primero.</p><a class="btn" href="${authUrl}">Conectar con Spotify</a>`;
+      }
+
+      async function onSearch() {
+        el('searchError').textContent = '';
+        el('authBox').classList.add('hidden');
+        const artistName = el('artistInput').value.trim();
+        if (!artistName) {
+          el('searchError').textContent = 'Ingresa un nombre de artista.';
+          return;
+        }
+
+        el('searchLoading').classList.remove('hidden');
+        el('searchBtn').disabled = true;
+        try {
+          const artists = await request('/api/search', { artist_name: artistName });
+          if (!artists.length) {
+            el('searchError').textContent = 'No se encontraron artistas.';
+          }
+          renderArtists(artists);
+        } catch (e) {
+          if (e.status === 401 && e.data?.auth_required) {
+            showAuth(e.data.auth_url);
+          } else {
+            el('searchError').textContent = e.message;
+          }
+        } finally {
+          el('searchLoading').classList.add('hidden');
+          el('searchBtn').disabled = false;
+        }
+      }
+
+      async function onCreate() {
+        el('createError').textContent = '';
+        if (!state.selectedArtist) {
+          el('createError').textContent = 'Selecciona un artista primero.';
+          return;
+        }
+
+        const payload = {
+          artist_id: state.selectedArtist.id,
+          artist_name: state.selectedArtist.name,
+          album_type_selection: Number(el('albumTypeSelect').value),
+          dry_run: el('dryRun').checked,
+          verbose: el('verbose').checked
+        };
+
+        el('createLoading').classList.remove('hidden');
+        el('createBtn').disabled = true;
+        try {
+          const result = await request('/api/create', payload);
+          el('resArtist').textContent = result.artist;
+          el('resPlaylist').textContent = result.playlist_name;
+          el('resAlbums').textContent = result.albums_included;
+          el('resTracks').textContent = result.tracks_added;
+
+          if (result.playlist_url) {
+            el('playlistLink').href = result.playlist_url;
+            el('playlistLinkWrap').classList.remove('hidden');
+          } else {
+            el('playlistLinkWrap').classList.add('hidden');
+          }
+          el('dryRunNote').classList.toggle('hidden', !result.dry_run);
+          el('step3').classList.remove('hidden');
+        } catch (e) {
+          if (e.status === 401 && e.data?.auth_required) {
+            showAuth(e.data.auth_url);
+          } else {
+            el('createError').textContent = e.message;
+          }
+        } finally {
+          el('createLoading').classList.add('hidden');
+          el('createBtn').disabled = false;
+        }
+      }
+
+      function onReset() {
+        state.selectedArtist = null;
+        el('artistInput').value = '';
+        el('artistsList').innerHTML = '';
+        el('searchError').textContent = '';
+        el('createError').textContent = '';
+        el('step2').classList.add('hidden');
+        el('step3').classList.add('hidden');
+      }
+
+      initTheme();
+      loadAlbumTypes();
+      el('searchBtn').onclick = onSearch;
+      el('createBtn').onclick = onCreate;
+      el('resetBtn').onclick = onReset;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Exponer la funcionalidad existente de `playlists.py` via HTTP para usarla desde un frontend y permitir despliegue en Railway.  
- Proveer una interfaz single‑page y un flujo OAuth compatible con entornos hosteados donde `open_browser=True` no funciona.  
- Mantener la lógica de Spotify sin modificar (`playlists.py` no fue tocado). 

### Description
- Nuevo backend Flask en `app.py` que instancia `SpotifyDiscographyCreator` por request y expone `POST /api/search`, `POST /api/create`, `GET /api/album-types`, `GET /callback` y `GET /` para servir la SPA, con errores JSON y CORS habilitado.  
- SPA en `templates/index.html` (único archivo) con HTML/CSS inline y JS vanilla que implementa búsqueda de artista, selección, configuración (tipos de álbum), creación (dry run/verbose), resultado y toggle de tema persistido en `localStorage`; estilo neon/terminal según especificación.  
- Archivos de despliegue añadidos: `Procfile` y `railway.toml` configurados para gunicorn y nixpacks con puerto dinámico vía `PORT`.  
- `requirements.txt` actualizado con `flask`, `gunicorn`, `spotipy`, `python-dotenv` y `flask-cors`.  
- Manejo de OAuth adaptado: cuando no hay token cached, las rutas API devuelven un payload con `auth_required` y `auth_url` para que el frontend redirija al usuario; `/callback` captura el código y completa el flujo. 

### Testing
- `python -m py_compile app.py playlists.py` ejecutado y completado con éxito.  
- `python -m compileall templates/index.html` ejecutado y completado con éxito.  
- `pip install -r requirements.txt` intentado pero falló por restricciones de red/proxy en el entorno (no por el código); instalación de dependencias en un entorno con salida de red permitirá ejecutar la app y los endpoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf986158a483318f04aa3b1f3cde64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Nuevas características**
  * Interfaz web con búsqueda de artistas integrada
  * Creación de listas de reproducción basadas en discografía
  * Configuración flexible de tipos de álbum
  * Modo de prueba y opciones de verbosidad
  * Palanca de tema para personalización visual
  * Flujo de trabajo de varios pasos: buscar, configurar y crear

<!-- end of auto-generated comment: release notes by coderabbit.ai -->