### PR TITLE
Add Flask web UI + API, deployment config, templates, and README updates

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app --bind 0.0.0.0:$PORT

--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
-# 🎵 Spotify Discography Playlist Creator
+# 🎵 DiscograPY — Spotify Discography Playlist Creator
 
 [![Python Version](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-This Python script uses the **Spotify Web API** (via [Spotipy](https://spotipy.readthedocs.io/)) to **automatically generate a playlist containing all the albums of a given artist in release order**.
+DiscograPY includes:
 
-The script has been **optimized for performance, scalability, error handling, and logging**, making it suitable for handling artists with large discographies while minimizing API rate-limit issues.
+- A **web app** (Flask + HTML/CSS/JS vanilla) to search artists and create discography playlists.
+- A **CLI script** (`playlists.py`) with the same Spotify discography logic.
+- Deployment config for **Railway**.
+
+The project uses the **Spotify Web API** through [Spotipy](https://spotipy.readthedocs.io/) and is optimized for performance, pagination, retries, and logging.
+
+## 🌐 Production
+
+Live app: **https://discograpy-production.up.railway.app/**
 
 ## 📋 Table of Contents
 
+- [Production](#-production)
 - [Features](#-features)
 - [Requirements](#️-requirements)
 - [Installation](#-installation)
 - [Setup](#-setup)
-- [Usage](#-usage)
-- [First Run](#-first-run)
+- [Usage (Web)](#-usage-web)
+- [Usage (CLI)](#-usage-cli)
 - [Project Structure](#-project-structure)
 - [Logging](#-logging)
-- [Technical Improvements](#-technical-improvements)
-- [Performance Optimization](#-performance-optimization)
-- [Permissions Required](#-permissions-required)
-- [Example Output](#-example-output)
-- [Notes & Limitations](#️-notes--limitations)
-- [Troubleshooting](#-troubleshooting)
-- [Contributing](#-contributing)
-- [License](#-license)
-- [Author](#-author)
 
 ---
 
 ## ✨ Features
 
 - Search for any artist on Spotify and select from all matching results.  
+- Web interface with 3-step flow (Search → Configure → Result).
+- Spotify embedded playlist preview after creation.
 - **Choose album types:** Everything, Albums only, EPs only, Singles only, Compilations only, or combinations (EPs + Singles, Albums + EPs + Singles).
 - Retrieve **all albums** (with pagination support).  
 - **Smart filtering:** Distinguishes between albums, EPs (4-7 tracks), and singles (1-3 tracks).
@@ -50,8 +52,11 @@ The script has been **optimized for performance, scalability, error handling, an
 - **Python 3.8+**  
 - **Spotify Developer Account** with API credentials  
 - Required Python packages:
+  - `flask` (web server)
+  - `gunicorn` (production WSGI server)
   - `spotipy` (Spotify Web API wrapper)
   - `python-dotenv` (Environment variable management)
+  - `flask-cors` (CORS support for API)
 
 ---
 
@@ -66,7 +71,7 @@ pip install -r requirements.txt
 ### Option 2: Manual installation
 
 ```bash
-pip install spotipy python-dotenv
+pip install flask gunicorn spotipy python-dotenv flask-cors
 ```
 
 ---
@@ -92,8 +97,16 @@ After creating your app, you'll see:
 1. In your app settings, click **"Edit Settings"**
 2. Add the following to **Redirect URIs**:
 
+For local web development:
+
 ```
-http://localhost:8888/callback/
+http://127.0.0.1:5000/callback
+```
+
+For production (Railway):
+
+```
+https://discograpy-production.up.railway.app/callback
 ```
 
 3. Click **"Add"** and then **"Save"**
@@ -105,14 +118,34 @@ Create a `.env` file in the project root directory:
 ```env
 SPOTIPY_CLIENT_ID=your_client_id_here
 SPOTIPY_CLIENT_SECRET=your_client_secret_here
-SPOTIPY_REDIRECT_URI=http://localhost:8888/callback/
+SPOTIPY_REDIRECT_URI=http://127.0.0.1:5000/callback
 ```
 
 ⚠️ **Important:** Never commit your `.env` file to version control. It's already included in `.gitignore`.
 
 ---
 
-## 🚀 Usage
+## 🚀 Usage (Web)
+
+Run the Flask app locally:
+
+```bash
+python app.py
+```
+
+Open:
+
+```text
+http://127.0.0.1:5000
+```
+
+For production-like local run:
+
+```bash
+gunicorn app:app --bind 0.0.0.0:5000
+```
+
+## 🚀 Usage (CLI)
 
 Run the script:
 
@@ -148,33 +181,19 @@ python playlists.py
 
 ---
 
-## 🔐 First Run
-
-On your first run, you'll need to authenticate with Spotify:
-
-1. The script will open a browser window automatically
-2. Log in to Spotify (if not already logged in)
-3. Click **"Agree"** to grant permissions
-4. You'll be redirected to `http://localhost:8888/callback/...`
-5. **Copy the entire URL** from your browser
-6. **Paste it back** into the terminal when prompted
-7. Press Enter
-
-The script will save your authentication token in a `.cache` file. Future runs won't require this step unless the token expires or is deleted.
-
----
-
 ## 📁 Project Structure
 
 ```
-discography/
-├── playlists.py           # Main script
+discograpy/
+├── app.py                 # Flask backend + API + routes
+├── playlists.py           # Existing Spotify discography logic (CLI + core methods)
+├── templates/
+│   └── index.html         # Single-page frontend
 ├── requirements.txt       # Python dependencies
-├── .env                   # Your API credentials (create this)
-├── .gitignore            # Git ignore rules
-├── README.md             # This file
-├── .cache                # Spotify auth token (auto-generated)
-└── spotify_discography.log  # Log file (auto-generated)
+├── Procfile               # Railway/Heroku process type
+├── railway.toml           # Railway deployment config
+├── README.md              # Documentation
+└── spotify_discography.log  # Runtime log file (generated)
 ```
 
 ---
@@ -573,7 +592,9 @@ Before running the script, ensure you have:
 - [x] Dependencies installed (`pip install -r requirements.txt`)
 - [x] Spotify Developer app created at [developer.spotify.com](https://developer.spotify.com/dashboard)
 - [x] `.env` file configured with `SPOTIPY_CLIENT_ID`, `SPOTIPY_CLIENT_SECRET`, and `SPOTIPY_REDIRECT_URI`
-- [x] Redirect URI set to `http://localhost:8888/callback/` in Spotify app settings
+- [x] Redirect URI set for your environment:
+  - Local: `http://127.0.0.1:5000/callback`
+  - Production: `https://discograpy-production.up.railway.app/callback`
 - [x] Ready for first-time authentication flow
 
 ---

--- a/app.py
+++ b/app.py
@@ -1,0 +1,201 @@
+import os
+from typing import Any, Dict, Optional
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, redirect, render_template, request, session, url_for
+from flask_cors import CORS
+from spotipy.exceptions import SpotifyException
+
+from playlists import SpotifyDiscographyCreator, configure_logging
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "discograpy-dev-secret")
+CORS(app)
+
+
+def _json_error(message: str, status_code: int = 400):
+    return jsonify({"error": message}), status_code
+
+
+def _creator(dry_run: bool = False, verbose: bool = False) -> SpotifyDiscographyCreator:
+    logger = configure_logging(verbose=verbose)
+    return SpotifyDiscographyCreator(logger=logger, dry_run=dry_run)
+
+
+def _build_auth_payload(creator: SpotifyDiscographyCreator) -> Dict[str, Any]:
+    auth_manager = creator.sp.auth_manager
+    auth_url = auth_manager.get_authorize_url()
+    return {
+        "error": "Spotify authentication required.",
+        "auth_required": True,
+        "auth_url": auth_url,
+    }
+
+
+def _ensure_spotify_token(creator: SpotifyDiscographyCreator) -> Optional[Dict[str, Any]]:
+    auth_manager = creator.sp.auth_manager
+    token_info = auth_manager.get_cached_token()
+    if token_info:
+        return None
+    session["spotify_auth_requested"] = True
+    return _build_auth_payload(creator)
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(error: Exception):
+    app.logger.exception("Unhandled error: %s", error)
+    return _json_error("Internal server error", 500)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/callback")
+def callback():
+    code = request.args.get("code")
+    error = request.args.get("error")
+
+    if error:
+        return redirect(url_for("index", oauth_error=error))
+
+    if not code:
+        return redirect(url_for("index", oauth_error="missing_code"))
+
+    try:
+        creator = _creator()
+        auth_manager = creator.sp.auth_manager
+        auth_manager.get_access_token(code=code, check_cache=False)
+        session["spotify_auth_requested"] = False
+        return redirect(url_for("index", oauth_success="1"))
+    except Exception:
+        app.logger.exception("OAuth callback failed")
+        return redirect(url_for("index", oauth_error="callback_failed"))
+
+
+@app.get("/api/album-types")
+def album_types():
+    options = []
+    for idx, cfg in SpotifyDiscographyCreator.ALBUM_TYPE_CONFIGS.items():
+        options.append(
+            {
+                "index": idx,
+                "label": cfg["suffix"],
+                "description": cfg["description"],
+                "types": cfg["types"],
+            }
+        )
+    return jsonify(options)
+
+
+@app.post("/api/search")
+def search_artist():
+    data = request.get_json(silent=True) or {}
+    artist_name = (data.get("artist_name") or "").strip()
+
+    if not artist_name:
+        return _json_error("artist_name is required", 400)
+
+    try:
+        creator = _creator()
+        auth_response = _ensure_spotify_token(creator)
+        if auth_response:
+            return jsonify(auth_response), 401
+
+        artists = creator.search_artists(artist_name)
+        serialized = [
+            {
+                "id": artist.get("id"),
+                "name": artist.get("name"),
+                "followers": artist.get("followers", {}).get("total", 0),
+                "genres": artist.get("genres", [])[:3],
+            }
+            for artist in artists
+            if artist.get("id")
+        ]
+        return jsonify(serialized)
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    except EnvironmentError as exc:
+        return _json_error(str(exc), 500)
+    except SpotifyException as exc:
+        return _json_error(creator._spotify_error_message(exc), exc.http_status or 502)
+
+
+@app.post("/api/create")
+def create_playlist():
+    data = request.get_json(silent=True) or {}
+
+    artist_id = (data.get("artist_id") or "").strip()
+    artist_name = (data.get("artist_name") or "").strip()
+    album_type_selection = data.get("album_type_selection", 0)
+    # Web flow always creates a playlist (dry-run disabled by product decision).
+    dry_run = False
+    verbose = bool(data.get("verbose", False))
+
+    if not artist_id or not artist_name:
+        return _json_error("artist_id and artist_name are required", 400)
+
+    if not isinstance(album_type_selection, int) or album_type_selection not in SpotifyDiscographyCreator.ALBUM_TYPE_CONFIGS:
+        return _json_error("album_type_selection must be an integer between 0 and 6", 400)
+
+    creator: Optional[SpotifyDiscographyCreator] = None
+    try:
+        creator = _creator(dry_run=dry_run, verbose=verbose)
+        auth_response = _ensure_spotify_token(creator)
+        if auth_response:
+            return jsonify(auth_response), 401
+
+        album_types = creator.get_album_types_from_selection(album_type_selection)
+        albums = creator._get_artist_albums(artist_id=artist_id, album_types=album_types)
+        filtered_albums, actual_types = creator.filter_albums_by_selection(albums, album_type_selection)
+
+        if not filtered_albums:
+            return _json_error("No albums found for selected filters", 404)
+
+        suffix = creator.get_playlist_suffix_from_selection(
+            album_type_selection,
+            actual_types if album_type_selection in (5, 6) else None,
+        )
+        playlist_name = f"{artist_name} discography {suffix}"
+
+        track_uris = creator._collect_tracks_from_albums(filtered_albums, verbose=verbose)
+        if not track_uris:
+            return _json_error("No tracks found for selected albums", 404)
+
+        playlist_id = None
+        playlist_url = None
+
+        if not dry_run:
+            playlist = creator._create_playlist(playlist_name, creator.PLAYLIST_DESCRIPTION)
+            playlist_id = playlist.get("id")
+            if playlist_id:
+                creator._add_tracks_to_playlist(playlist_id, track_uris)
+                playlist_url = f"https://open.spotify.com/playlist/{playlist_id}"
+
+        response = {
+            "artist": artist_name,
+            "playlist_name": playlist_name,
+            "playlist_id": playlist_id,
+            "playlist_url": playlist_url,
+            "albums_included": len(filtered_albums),
+            "tracks_added": len(track_uris),
+            "dry_run": dry_run,
+        }
+        return jsonify(response)
+    except ValueError as exc:
+        return _json_error(str(exc), 400)
+    except EnvironmentError as exc:
+        return _json_error(str(exc), 500)
+    except SpotifyException as exc:
+        status = exc.http_status or 502
+        message = creator._spotify_error_message(exc) if creator else str(exc)
+        return _json_error(message, status)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "gunicorn app:app --bind 0.0.0.0:$PORT"
+healthcheckPath = "/"
+restartPolicyType = "on_failure"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-spotipy>=2.23.0
-python-dotenv>=1.0.0
+flask
+gunicorn
+spotipy
+python-dotenv
+flask-cors

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,377 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DiscograPY</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <style>
+      :root {
+        --accent: #39ff14;
+        --accent-2: #00e676;
+        --bg: #0a0a0a;
+        --card: #111111;
+        --text: #e0e0e0;
+        --error: #ff4d4d;
+        --border: rgba(57, 255, 20, 0.35);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: "Space Mono", monospace;
+        background: var(--bg);
+        color: var(--text);
+      }
+      .container { max-width: 920px; margin: 24px auto; padding: 20px; }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 20px;
+        margin-bottom: 18px;
+        box-shadow: 0 0 10px rgba(57, 255, 20, 0.15);
+      }
+      .header { position: relative; }
+      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
+      .subtitle { margin: 0 0 16px; opacity: .85; }
+      .theme-toggle { position: absolute; top: 0; right: 0; }
+
+      button, .btn {
+        border: 1px solid var(--accent);
+        background: transparent;
+        color: var(--accent);
+        padding: 10px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+        font-family: inherit;
+        text-decoration: none;
+        box-shadow: 0 0 10px rgba(57, 255, 20, 0.45);
+      }
+      button:disabled { opacity: .55; cursor: not-allowed; box-shadow: none; }
+
+      input {
+        width: 100%;
+        margin-top: 8px;
+        margin-bottom: 12px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        padding: 10px;
+        background: transparent;
+        color: var(--text);
+        font-family: inherit;
+      }
+
+      .artists-list { max-height: 250px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
+      .artist-item { border: 1px solid var(--border); border-radius: 8px; padding: 10px; cursor: pointer; }
+      .artist-item.selected { border-color: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.5); }
+
+      .album-type-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 10px;
+        margin-top: 10px;
+      }
+      .album-type-btn {
+        text-align: left;
+        width: 100%;
+        min-height: 84px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .album-type-btn small { color: var(--text); opacity: 0.78; }
+      .album-type-btn.selected {
+        background: rgba(57, 255, 20, 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 14px rgba(57, 255, 20, 0.65);
+      }
+
+      .result-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        margin-top: 14px;
+        align-items: flex-start;
+      }
+      .embed-wrap {
+        width: 100%;
+        max-width: 680px;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 0 10px rgba(57, 255, 20, 0.18);
+      }
+      .embed-wrap iframe {
+        width: 100%;
+        min-height: 352px;
+        border: 0;
+        display: block;
+      }
+
+      .hidden { display: none; }
+      .muted { opacity: .8; font-size: .9rem; }
+      .error { color: var(--error); margin-top: 8px; }
+      .spinner {
+        width: 28px;
+        height: 28px;
+        border: 3px solid rgba(57, 255, 20, 0.2);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+        margin-right: 10px;
+      }
+      .loading { display: flex; align-items: center; margin-top: 10px; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      footer { text-align: center; margin: 20px 0 5px; }
+      footer a { color: var(--accent-2); }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <section class="card header">
+        <button id="themeToggle" class="theme-toggle">☾/☀</button>
+        <h1>DiscograPY</h1>
+        <p class="subtitle">Spotify Discography Playlist Creator</p>
+      </section>
+
+      <section class="card" id="step1">
+        <h2>Step 1 — Search artist</h2>
+        <label for="artistInput">Artist name</label>
+        <input id="artistInput" type="text" placeholder="Example: Daft Punk" />
+        <button id="searchBtn">Search</button>
+        <div id="searchLoading" class="loading hidden"><div class="spinner"></div><span>Searching artists…</span></div>
+        <div id="searchError" class="error"></div>
+        <div id="authBox" class="hidden"></div>
+        <div id="artistsList" class="artists-list"></div>
+      </section>
+
+      <section class="card hidden" id="step2">
+        <h2>Step 2 — Configure playlist</h2>
+        <p>Selected artist: <strong id="selectedArtist"></strong></p>
+
+        <h3>Playlist type</h3>
+        <div id="albumTypeButtons" class="album-type-grid"></div>
+
+        <button id="createBtn">Create playlist</button>
+        <div id="createLoading" class="loading hidden"><div class="spinner"></div><span>Creating your discography playlist…</span></div>
+        <div id="createError" class="error"></div>
+      </section>
+
+      <section class="card hidden" id="step3">
+        <h2>Step 3 — Result</h2>
+        <p><strong>Artist:</strong> <span id="resArtist"></span></p>
+        <p><strong>Playlist:</strong> <span id="resPlaylist"></span></p>
+        <p><strong>Albums included:</strong> <span id="resAlbums"></span></p>
+        <p><strong>Tracks added:</strong> <span id="resTracks"></span></p>
+        <div class="result-actions">
+          <div id="playlistEmbedWrap" class="embed-wrap hidden">
+            <iframe id="playlistEmbed" loading="lazy" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+          </div>
+          <button id="resetBtn">Start over</button>
+        </div>
+      </section>
+
+      <footer>
+        <a href="https://github.com/based-on-what/discograpy" target="_blank" rel="noopener noreferrer">DiscograPY - Coded with ❤️ by @based-on-what</a>
+      </footer>
+    </div>
+
+    <script>
+      const state = { selectedArtist: null, selectedAlbumType: 0, albumTypes: [] };
+      const el = (id) => document.getElementById(id);
+
+      const albumTypeDescriptions = {
+        0: { title: 'Everything', detail: 'Include absolutely everything available on Spotify: LPs, EPs, Singles, and Compilations.' },
+        1: { title: 'LPs only', detail: 'Include full-length albums only (LPs / album releases).' },
+        2: { title: 'EPs only', detail: 'Include only EP releases (single-type releases with 4–7 tracks).' },
+        3: { title: 'Singles only', detail: 'Include only singles (single-type releases with up to 3 tracks).' },
+        4: { title: 'Compilations only', detail: 'Include only compilation releases.' },
+        5: { title: 'EPs + Singles', detail: 'Include EP releases and Singles, excluding LPs and Compilations.' },
+        6: { title: 'LPs + EPs + Singles', detail: 'Include LP albums, EP releases, and Singles (no Compilations).' }
+      };
+
+      function applyTheme(mode) {
+        const dark = mode !== 'light';
+        const vars = dark
+          ? { '--bg': '#0a0a0a', '--card': '#111111', '--text': '#e0e0e0' }
+          : { '--bg': '#f0f0f0', '--card': '#ffffff', '--text': '#1a1a1a' };
+        Object.entries(vars).forEach(([k, v]) => document.documentElement.style.setProperty(k, v));
+      }
+
+      function initTheme() {
+        const stored = localStorage.getItem('discograpy-theme') || 'dark';
+        applyTheme(stored);
+        el('themeToggle').onclick = () => {
+          const current = localStorage.getItem('discograpy-theme') || 'dark';
+          const next = current === 'dark' ? 'light' : 'dark';
+          localStorage.setItem('discograpy-theme', next);
+          applyTheme(next);
+        };
+      }
+
+      async function request(path, payload) {
+        const res = await fetch(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          const err = new Error(data.error || 'Unexpected error');
+          err.data = data;
+          err.status = res.status;
+          throw err;
+        }
+        return data;
+      }
+
+      function renderAlbumTypeButtons() {
+        const wrap = el('albumTypeButtons');
+        wrap.innerHTML = '';
+
+        state.albumTypes.forEach((item) => {
+          const text = albumTypeDescriptions[item.index] || { title: item.label, detail: item.description || '' };
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = `album-type-btn ${state.selectedAlbumType === item.index ? 'selected' : ''}`;
+          btn.innerHTML = `<strong>${text.title}</strong><small>${text.detail}</small>`;
+          btn.onclick = () => {
+            state.selectedAlbumType = item.index;
+            renderAlbumTypeButtons();
+          };
+          wrap.appendChild(btn);
+        });
+      }
+
+      async function loadAlbumTypes() {
+        const res = await fetch('/api/album-types');
+        const data = await res.json();
+        state.albumTypes = data;
+        state.selectedAlbumType = 0;
+        renderAlbumTypeButtons();
+      }
+
+      function renderArtists(artists) {
+        const list = el('artistsList');
+        list.innerHTML = '';
+        artists.forEach((artist) => {
+          const item = document.createElement('div');
+          item.className = 'artist-item';
+          item.innerHTML = `<strong>${artist.name}</strong><br><span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'n/a'}</span>`;
+          item.onclick = () => {
+            Array.from(document.querySelectorAll('.artist-item')).forEach((n) => n.classList.remove('selected'));
+            item.classList.add('selected');
+            state.selectedArtist = artist;
+            el('selectedArtist').textContent = artist.name;
+            el('step2').classList.remove('hidden');
+            el('createError').textContent = '';
+          };
+          list.appendChild(item);
+        });
+      }
+
+      function showAuth(authUrl) {
+        el('authBox').classList.remove('hidden');
+        el('authBox').innerHTML = `<p class="error">You must authenticate with Spotify first.</p><a class="btn" href="${authUrl}">Connect with Spotify</a>`;
+      }
+
+      async function onSearch() {
+        el('searchLoading').classList.add('hidden');
+        el('searchError').textContent = '';
+        el('authBox').classList.add('hidden');
+        const artistName = el('artistInput').value.trim();
+        if (!artistName) {
+          el('searchError').textContent = 'Please enter an artist name.';
+          return;
+        }
+
+        el('searchLoading').classList.remove('hidden');
+        el('searchBtn').disabled = true;
+        try {
+          const artists = await request('/api/search', { artist_name: artistName });
+          if (!artists.length) {
+            el('searchError').textContent = 'No artists found.';
+          }
+          renderArtists(artists);
+        } catch (e) {
+          if (e.status === 401 && e.data?.auth_required) {
+            showAuth(e.data.auth_url);
+          } else {
+            el('searchError').textContent = e.message;
+          }
+        } finally {
+          el('searchLoading').classList.add('hidden');
+          el('searchBtn').disabled = false;
+        }
+      }
+
+      async function onCreate() {
+        el('createLoading').classList.add('hidden');
+        el('createError').textContent = '';
+        if (!state.selectedArtist) {
+          el('createError').textContent = 'Please select an artist first.';
+          return;
+        }
+
+        const payload = {
+          artist_id: state.selectedArtist.id,
+          artist_name: state.selectedArtist.name,
+          album_type_selection: Number(state.selectedAlbumType),
+          dry_run: false,
+          verbose: false
+        };
+
+        el('createLoading').classList.remove('hidden');
+        el('createBtn').disabled = true;
+        try {
+          const result = await request('/api/create', payload);
+          el('resArtist').textContent = result.artist;
+          el('resPlaylist').textContent = result.playlist_name;
+          el('resAlbums').textContent = result.albums_included;
+          el('resTracks').textContent = result.tracks_added;
+
+          if (result.playlist_id) {
+            el('playlistEmbed').src = `https://open.spotify.com/embed/playlist/${result.playlist_id}?utm_source=generator`;
+            el('playlistEmbedWrap').classList.remove('hidden');
+          } else {
+            el('playlistEmbedWrap').classList.add('hidden');
+          }
+          el('step3').classList.remove('hidden');
+        } catch (e) {
+          if (e.status === 401 && e.data?.auth_required) {
+            showAuth(e.data.auth_url);
+          } else {
+            el('createError').textContent = e.message;
+          }
+        } finally {
+          el('createLoading').classList.add('hidden');
+          el('createBtn').disabled = false;
+        }
+      }
+
+      function onReset() {
+        state.selectedArtist = null;
+        state.selectedAlbumType = 0;
+        el('artistInput').value = '';
+        el('artistsList').innerHTML = '';
+        el('searchError').textContent = '';
+        el('createError').textContent = '';
+        el('searchLoading').classList.add('hidden');
+        el('createLoading').classList.add('hidden');
+        el('playlistEmbedWrap').classList.add('hidden');
+        el('playlistEmbed').src = '';
+        el('step2').classList.add('hidden');
+        el('step3').classList.add('hidden');
+        renderAlbumTypeButtons();
+      }
+
+      initTheme();
+      loadAlbumTypes();
+      el('searchBtn').onclick = onSearch;
+      el('createBtn').onclick = onCreate;
+      el('resetBtn').onclick = onReset;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Expose the Spotify discography functionality via a web UI and REST API for easier usage and deployment.
- Prepare the project for Railway/Heroku-like deployment with a Procfile and `railway.toml` start command.
- Add a single-page frontend so users can authenticate with Spotify and create playlists through a 3-step flow.

### Description
- Added a new Flask app entrypoint in `app.py` providing routes `GET /`, `GET /callback`, `POST /api/search`, `POST /api/create`, and `GET /api/album-types` and using `SpotifyDiscographyCreator` from `playlists.py` for core logic.
- Added the single-page frontend `templates/index.html` implementing the search → configure → result flow, theme toggle, and embedded playlist preview.
- Added deployment/config files: `Procfile` and `railway.toml`, and updated `requirements.txt` to include `flask`, `gunicorn`, and `flask-cors`.
- Updated `README.md` to document the web app, CLI usage, redirect URIs, project structure, and local/production run examples.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf986158a483318f04aa3b1f3cde64)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Nuevas Características**
  * Aplicación web con interfaz para buscar artistas y crear listas de reproducción personalizadas
  * Selección configurable de tipos de álbum a incluir
  * Vista previa integrada de playlists de Spotify
  * Tema oscuro y claro con preferencias guardadas
  * Despliegue disponible en producción

* **Documentación**
  * Instrucciones actualizadas para la aplicación web y la interfaz CLI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->