### PR TITLE
Enhance artist search metadata and theme/spacing visuals

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,7 +116,9 @@ def search_artist():
                 "id": artist.get("id"),
                 "name": artist.get("name"),
                 "followers": artist.get("followers", {}).get("total", 0),
-                "genres": artist.get("genres", [])[:3],
+                "genres": creator._infer_genres(artist),
+                "image_url": (artist.get("images") or [{}])[0].get("url"),
+                "country": creator._lookup_artist_country(artist.get("name", "")) or "Unknown",
             }
             for artist in artists
             if artist.get("id")

--- a/playlists.py
+++ b/playlists.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+import requests
 import spotipy
 from dotenv import load_dotenv
 from spotipy.exceptions import SpotifyException
@@ -338,6 +339,75 @@ class SpotifyDiscographyCreator:
             raise ValueError("Artist name cannot be empty")
         results = self.sp.search(q=f"artist:{artist_name}", type="artist", limit=50)
         return self._paginate_spotify_results(results, "items")
+
+    @retry_on_failure(max_retries=3)
+    def _get_related_artists(self, artist_id: str) -> List[Dict[str, Any]]:
+        data = self.sp.artist_related_artists(artist_id)
+        return data.get("artists", []) if data else []
+
+    def _infer_genres(self, artist: Dict[str, Any]) -> List[str]:
+        artist_genres = [genre for genre in artist.get("genres", []) if genre]
+        if artist_genres:
+            return artist_genres[:3]
+
+        artist_id = artist.get("id")
+        if not artist_id:
+            return []
+
+        try:
+            related = self._get_related_artists(artist_id)
+        except SpotifyException:
+            return []
+
+        ranked: Dict[str, int] = {}
+        for related_artist in related:
+            for genre in related_artist.get("genres", []):
+                ranked[genre] = ranked.get(genre, 0) + 1
+
+        return [genre for genre, _ in sorted(ranked.items(), key=lambda item: item[1], reverse=True)[:3]]
+
+    def _lookup_artist_country(self, artist_name: str) -> Optional[str]:
+        if not artist_name:
+            return None
+
+        endpoint = "https://musicbrainz.org/ws/2/artist/"
+        params = {"query": f'artist:"{artist_name}"', "fmt": "json", "limit": 5}
+        headers = {"User-Agent": "DiscograPY/1.0 (https://github.com/based-on-what/discograpy)"}
+
+        try:
+            response = requests.get(endpoint, params=params, headers=headers, timeout=2.5)
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException:
+            return None
+        except ValueError:
+            return None
+
+        candidates = payload.get("artists", []) if isinstance(payload, dict) else []
+        if not candidates:
+            return None
+
+        normalized_name = artist_name.strip().casefold()
+        exact_match = next(
+            (
+                artist
+                for artist in candidates
+                if str(artist.get("name", "")).strip().casefold() == normalized_name
+            ),
+            None,
+        )
+        chosen = exact_match or max(candidates, key=lambda item: int(item.get("score", 0)))
+
+        country = chosen.get("country")
+        if country:
+            return country
+
+        area = chosen.get("area")
+        if isinstance(area, dict):
+            area_name = area.get("name")
+            if area_name:
+                return str(area_name)
+        return None
 
     def display_artists(self, artists: List[Dict[str, Any]]) -> None:
         print(f"\nFound {len(artists)} artists:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 spotipy
 python-dotenv
 flask-cors
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,11 @@
         --text: #e0e0e0;
         --error: #ff4d4d;
         --border: rgba(57, 255, 20, 0.35);
+        --selected-bg: rgba(57, 255, 20, 0.14);
       }
       * { box-sizing: border-box; }
+      html { color-scheme: dark; }
+      html[data-theme='light'] { color-scheme: light; }
       body {
         margin: 0;
         font-family: "Space Mono", monospace;
@@ -63,9 +66,38 @@
         font-family: inherit;
       }
 
-      .artists-list { max-height: 250px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
-      .artist-item { border: 1px solid var(--border); border-radius: 8px; padding: 10px; cursor: pointer; }
-      .artist-item.selected { border-color: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.5); }
+      .artists-list { max-height: 320px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
+      .artist-item {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px;
+        cursor: pointer;
+        display: grid;
+        grid-template-columns: 56px 1fr;
+        gap: 12px;
+        align-items: center;
+      }
+      .artist-item.selected {
+        border-color: var(--accent);
+        box-shadow: 0 0 12px rgba(57, 255, 20, 0.5);
+        background: var(--selected-bg);
+      }
+      .artist-photo {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 1px solid var(--border);
+      }
+      .artist-photo-placeholder {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--border);
+        opacity: 0.8;
+      }
 
       .album-type-grid {
         display: grid;
@@ -83,10 +115,11 @@
       }
       .album-type-btn small { color: var(--text); opacity: 0.78; }
       .album-type-btn.selected {
-        background: rgba(57, 255, 20, 0.1);
+        background: var(--selected-bg);
         border-color: var(--accent);
         box-shadow: 0 0 14px rgba(57, 255, 20, 0.65);
       }
+      #createBtn { margin-top: 18px; }
 
       .result-actions {
         display: flex;
@@ -195,9 +228,26 @@
       function applyTheme(mode) {
         const dark = mode !== 'light';
         const vars = dark
-          ? { '--bg': '#0a0a0a', '--card': '#111111', '--text': '#e0e0e0' }
-          : { '--bg': '#f0f0f0', '--card': '#ffffff', '--text': '#1a1a1a' };
+          ? {
+              '--bg': '#0a0a0a',
+              '--card': '#111111',
+              '--text': '#e0e0e0',
+              '--accent': '#39ff14',
+              '--accent-2': '#00e676',
+              '--border': 'rgba(57, 255, 20, 0.35)',
+              '--selected-bg': 'rgba(112, 255, 84, 0.34)'
+            }
+          : {
+              '--bg': '#f3f3f3',
+              '--card': '#ffffff',
+              '--text': '#ff073a',
+              '--accent': '#ff073a',
+              '--accent-2': '#ff4f72',
+              '--border': 'rgba(255, 7, 58, 0.45)',
+              '--selected-bg': 'rgba(255, 7, 58, 0.2)'
+            };
         Object.entries(vars).forEach(([k, v]) => document.documentElement.style.setProperty(k, v));
+        document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
       }
 
       function initTheme() {
@@ -268,7 +318,16 @@
         artists.forEach((artist) => {
           const item = document.createElement('div');
           item.className = 'artist-item';
-          item.innerHTML = `<strong>${artist.name}</strong><br><span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'n/a'}</span>`;
+          const photo = artist.image_url
+            ? `<img class="artist-photo" src="${artist.image_url}" alt="Photo of ${artist.name}" loading="lazy" />`
+            : `<div class="artist-photo-placeholder">🎵</div>`;
+          item.innerHTML = `
+            ${photo}
+            <div>
+              <strong>${artist.name}</strong><br>
+              <span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'not available'} · Country: ${artist.country || 'Unknown'}</span>
+            </div>
+          `;
           item.onclick = () => {
             Array.from(document.querySelectorAll('.artist-item')).forEach((n) => n.classList.remove('selected'));
             item.classList.add('selected');


### PR DESCRIPTION
### Motivation
- Fix unreliable artist genre detection shown as `n/a` by improving how genres are determined for search results. 
- Surface richer artist information (profile photo and country) in search results to help user selection. 
- Improve spacing around the "Create playlist" action and correct light/dark theme behavior on mobile. 
- Apply requested visual rules: neon-red text in light theme and inverted selected-state brightness between dark and light themes. 

### Description
- Backend: add genre inference by checking related artists via `SpotifyDiscographyCreator._get_related_artists` and a new `_infer_genres` helper, and add a MusicBrainz lookup `SpotifyDiscographyCreator._lookup_artist_country` using `requests` for country resolution; wire these into the `/api/search` response in `app.py` (adds `genres`, `image_url`, and `country`).
- Frontend: update `templates/index.html` to show artist profile image, followers, inferred genres and country in each result card, increase vertical gap before the `#createBtn`, and add a `--selected-bg` CSS variable and layout changes for selected states. 
- Theme/UX: add explicit `color-scheme` metadata via `html[data-theme]` and set `data-theme` on theme changes; implement light-theme neon red text/accent and ensure selected album-type buttons become lighter in dark mode and darker in light mode. 
- Dependencies: add `requests` to `requirements.txt` to support MusicBrainz API queries. 

### Testing
- Compiled changed Python modules with `python -m compileall app.py playlists.py` and the compilation completed without runtime compile errors. 
- Ran `python -m pytest -q`; the repository contains no automated tests so pytest reported "no tests ran" (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1733372788331a0517bad3c595cd5)