### PR TITLE
Enhance artist search with images, inferred genres and country; add MusicBrainz lookup and UI improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,16 +111,26 @@ def search_artist():
             return jsonify(auth_response), 401
 
         artists = creator.search_artists(artist_name)
-        serialized = [
-            {
-                "id": artist.get("id"),
-                "name": artist.get("name"),
-                "followers": artist.get("followers", {}).get("total", 0),
-                "genres": artist.get("genres", [])[:3],
-            }
-            for artist in artists
-            if artist.get("id")
-        ]
+        serialized = []
+        for idx, artist in enumerate(artists):
+            if not artist.get("id"):
+                continue
+
+            serialized.append(
+                {
+                    "id": artist.get("id"),
+                    "name": artist.get("name"),
+                    "followers": artist.get("followers", {}).get("total", 0),
+                    "genres": creator._infer_genres(artist, use_related=idx < 5),
+                    "image_url": (artist.get("images") or [{}])[0].get("url"),
+                    "country": (
+                        creator._lookup_artist_country(artist.get("name", ""))
+                        if idx < 5
+                        else "Unknown"
+                    )
+                    or "Unknown",
+                }
+            )
         return jsonify(serialized)
     except ValueError as exc:
         return _json_error(str(exc), 400)

--- a/playlists.py
+++ b/playlists.py
@@ -8,9 +8,10 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+import requests
 import spotipy
 from dotenv import load_dotenv
 from spotipy.exceptions import SpotifyException
@@ -336,8 +337,85 @@ class SpotifyDiscographyCreator:
     def search_artists(self, artist_name: str) -> List[Dict[str, Any]]:
         if not artist_name.strip():
             raise ValueError("Artist name cannot be empty")
-        results = self.sp.search(q=f"artist:{artist_name}", type="artist", limit=50)
-        return self._paginate_spotify_results(results, "items")
+        results = self.sp.search(q=f"artist:{artist_name}", type="artist", limit=12)
+        return results.get("artists", {}).get("items", [])
+
+    @retry_on_failure(max_retries=3)
+    def _get_related_artists(self, artist_id: str) -> List[Dict[str, Any]]:
+        data = self.sp.artist_related_artists(artist_id)
+        return data.get("artists", []) if data else []
+
+    def _infer_genres(self, artist: Dict[str, Any], use_related: bool = True) -> List[str]:
+        artist_genres = [genre for genre in artist.get("genres", []) if genre]
+        if artist_genres:
+            return artist_genres[:3]
+
+        if not use_related:
+            return []
+
+        artist_id = artist.get("id")
+        if not artist_id:
+            return []
+
+        try:
+            related = self._get_related_artists(artist_id)
+        except SpotifyException:
+            return []
+
+        ranked: Dict[str, int] = {}
+        for related_artist in related:
+            for genre in related_artist.get("genres", []):
+                ranked[genre] = ranked.get(genre, 0) + 1
+
+        return [genre for genre, _ in sorted(ranked.items(), key=lambda item: item[1], reverse=True)[:3]]
+
+    @staticmethod
+    @lru_cache(maxsize=2048)
+    def _lookup_artist_country_cached(artist_name: str) -> Optional[str]:
+        if not artist_name:
+            return None
+
+        endpoint = "https://musicbrainz.org/ws/2/artist/"
+        params = {"query": f'artist:"{artist_name}"', "fmt": "json", "limit": 5}
+        headers = {"User-Agent": "DiscograPY/1.0 (https://github.com/based-on-what/discograpy)"}
+
+        try:
+            response = requests.get(endpoint, params=params, headers=headers, timeout=1.2)
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException:
+            return None
+        except ValueError:
+            return None
+
+        candidates = payload.get("artists", []) if isinstance(payload, dict) else []
+        if not candidates:
+            return None
+
+        normalized_name = artist_name.strip().casefold()
+        exact_match = next(
+            (
+                artist
+                for artist in candidates
+                if str(artist.get("name", "")).strip().casefold() == normalized_name
+            ),
+            None,
+        )
+        chosen = exact_match or max(candidates, key=lambda item: int(item.get("score", 0)))
+
+        country = chosen.get("country")
+        if country:
+            return country
+
+        area = chosen.get("area")
+        if isinstance(area, dict):
+            area_name = area.get("name")
+            if area_name:
+                return str(area_name)
+        return None
+
+    def _lookup_artist_country(self, artist_name: str) -> Optional[str]:
+        return self._lookup_artist_country_cached((artist_name or "").strip())
 
     def display_artists(self, artists: List[Dict[str, Any]]) -> None:
         print(f"\nFound {len(artists)} artists:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 spotipy
 python-dotenv
 flask-cors
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,12 @@
         --text: #e0e0e0;
         --error: #ff4d4d;
         --border: rgba(57, 255, 20, 0.35);
+        --accent-rgb: 57, 255, 20;
+        --selected-bg: rgba(57, 255, 20, 0.14);
       }
       * { box-sizing: border-box; }
+      html { color-scheme: dark; }
+      html[data-theme='light'] { color-scheme: light; }
       body {
         margin: 0;
         font-family: "Space Mono", monospace;
@@ -31,10 +35,10 @@
         border-radius: 12px;
         padding: 20px;
         margin-bottom: 18px;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.15);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.15);
       }
       .header { position: relative; }
-      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
+      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(var(--accent-rgb), 0.8); }
       .subtitle { margin: 0 0 16px; opacity: .85; }
       .theme-toggle { position: absolute; top: 0; right: 0; }
 
@@ -47,7 +51,7 @@
         cursor: pointer;
         font-family: inherit;
         text-decoration: none;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.45);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.45);
       }
       button:disabled { opacity: .55; cursor: not-allowed; box-shadow: none; }
 
@@ -63,9 +67,38 @@
         font-family: inherit;
       }
 
-      .artists-list { max-height: 250px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
-      .artist-item { border: 1px solid var(--border); border-radius: 8px; padding: 10px; cursor: pointer; }
-      .artist-item.selected { border-color: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.5); }
+      .artists-list { max-height: 320px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
+      .artist-item {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px;
+        cursor: pointer;
+        display: grid;
+        grid-template-columns: 56px 1fr;
+        gap: 12px;
+        align-items: center;
+      }
+      .artist-item.selected {
+        border-color: var(--accent);
+        box-shadow: 0 0 12px rgba(var(--accent-rgb), 0.5);
+        background: var(--selected-bg);
+      }
+      .artist-photo {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 1px solid var(--border);
+      }
+      .artist-photo-placeholder {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--border);
+        opacity: 0.8;
+      }
 
       .album-type-grid {
         display: grid;
@@ -83,10 +116,11 @@
       }
       .album-type-btn small { color: var(--text); opacity: 0.78; }
       .album-type-btn.selected {
-        background: rgba(57, 255, 20, 0.1);
+        background: var(--selected-bg);
         border-color: var(--accent);
-        box-shadow: 0 0 14px rgba(57, 255, 20, 0.65);
+        box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.65);
       }
+      #createBtn { margin-top: 18px; }
 
       .result-actions {
         display: flex;
@@ -101,7 +135,7 @@
         border: 1px solid var(--border);
         border-radius: 12px;
         overflow: hidden;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.18);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.18);
       }
       .embed-wrap iframe {
         width: 100%;
@@ -115,7 +149,7 @@
       .spinner {
         width: 28px;
         height: 28px;
-        border: 3px solid rgba(57, 255, 20, 0.2);
+        border: 3px solid rgba(var(--accent-rgb), 0.2);
         border-top-color: var(--accent);
         border-radius: 50%;
         animation: spin 0.8s linear infinite;
@@ -195,9 +229,28 @@
       function applyTheme(mode) {
         const dark = mode !== 'light';
         const vars = dark
-          ? { '--bg': '#0a0a0a', '--card': '#111111', '--text': '#e0e0e0' }
-          : { '--bg': '#f0f0f0', '--card': '#ffffff', '--text': '#1a1a1a' };
+          ? {
+              '--bg': '#0a0a0a',
+              '--card': '#111111',
+              '--text': '#e0e0e0',
+              '--accent': '#39ff14',
+              '--accent-2': '#00e676',
+              '--border': 'rgba(57, 255, 20, 0.35)',
+              '--accent-rgb': '57, 255, 20',
+              '--selected-bg': 'rgba(112, 255, 84, 0.34)'
+            }
+          : {
+              '--bg': '#f3f3f3',
+              '--card': '#ffffff',
+              '--text': '#ff073a',
+              '--accent': '#ff073a',
+              '--accent-2': '#ff4f72',
+              '--border': 'rgba(255, 7, 58, 0.45)',
+              '--accent-rgb': '255, 7, 58',
+              '--selected-bg': 'rgba(255, 7, 58, 0.2)'
+            };
         Object.entries(vars).forEach(([k, v]) => document.documentElement.style.setProperty(k, v));
+        document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
       }
 
       function initTheme() {
@@ -217,7 +270,13 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        const data = await res.json();
+        const raw = await res.text();
+        let data = {};
+        try {
+          data = raw ? JSON.parse(raw) : {};
+        } catch (_e) {
+          data = { error: `Server returned a non-JSON response (${res.status}).` };
+        }
         if (!res.ok) {
           const err = new Error(data.error || 'Unexpected error');
           err.data = data;
@@ -268,7 +327,16 @@
         artists.forEach((artist) => {
           const item = document.createElement('div');
           item.className = 'artist-item';
-          item.innerHTML = `<strong>${artist.name}</strong><br><span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'n/a'}</span>`;
+          const photo = artist.image_url
+            ? `<img class="artist-photo" src="${artist.image_url}" alt="Photo of ${artist.name}" loading="lazy" />`
+            : `<div class="artist-photo-placeholder">🎵</div>`;
+          item.innerHTML = `
+            ${photo}
+            <div>
+              <strong>${artist.name}</strong><br>
+              <span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'not available'} · Country: ${artist.country || 'Unknown'}</span>
+            </div>
+          `;
           item.onclick = () => {
             Array.from(document.querySelectorAll('.artist-item')).forEach((n) => n.classList.remove('selected'));
             item.classList.add('selected');


### PR DESCRIPTION
### Motivation
- Improve the artist search results returned by the API by providing richer metadata (genres, image, country) and prioritize accuracy for the top results.
- Reduce noisy/slow Spotify queries by limiting search results and inferring missing genre info from related artists.
- Provide a nicer, more resilient web UI with theme toggling, artist photos/placeholders, and robust handling of non-JSON server responses.

### Description
- Updated `/api/search` to serialize each artist with `id`, `name`, `followers`, `genres` (inferred via new logic), `image_url`, and `country`, and to only use related-artist lookups / country lookups for the top results.
- Modified `SpotifyDiscographyCreator.search_artists` to use a smaller result set (`limit=12`) for faster responses and simpler handling.
- Added `_get_related_artists` (with retry), `_infer_genres`, and a cached MusicBrainz lookup (`_lookup_artist_country_cached` using `functools.lru_cache`) with a thin wrapper `_lookup_artist_country` in `playlists.py` to infer missing genres and artist country info.
- Imported `requests` and added it to `requirements.txt` to perform MusicBrainz HTTP queries, and added `lru_cache` to reduce repeated lookups.
- Enhanced `templates/index.html` with a theme toggle (dark/light), updated CSS variables and styles, expanded artist list UI to include photos/placeholders and country display, moved to safer `request()` logic that tolerates non-JSON responses, and general UI/UX tweaks (spacing, selected styles, loading states).

### Testing
- Ran the existing automated test suite with `pytest`; tests completed successfully and reported no failures.
- Ran static checks with `flake8`/basic linter; no new issues were reported.
- Performed local API smoke tests for `/api/search` to confirm the new serialized fields (`genres`, `image_url`, `country`) are returned as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1733372788331a0517bad3c595cd5)