### PR TITLE
Enhance artist search with MusicBrainz metadata, caching, and UI improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,16 +111,26 @@ def search_artist():
             return jsonify(auth_response), 401
 
         artists = creator.search_artists(artist_name)
-        serialized = [
-            {
-                "id": artist.get("id"),
-                "name": artist.get("name"),
-                "followers": artist.get("followers", {}).get("total", 0),
-                "genres": artist.get("genres", [])[:3],
-            }
-            for artist in artists
-            if artist.get("id")
-        ]
+        serialized = []
+        for artist in artists:
+            if not artist.get("id"):
+                continue
+
+            mb_data = creator._lookup_artist_metadata(artist.get("name", ""))
+            mb_genres = [genre for genre in (mb_data.get("genres") or []) if genre][:3]
+            spotify_genres = [genre for genre in (artist.get("genres") or []) if genre][:3]
+            genres = mb_genres or spotify_genres
+
+            serialized.append(
+                {
+                    "id": artist.get("id"),
+                    "name": artist.get("name"),
+                    "followers": artist.get("followers", {}).get("total", 0),
+                    "genres": genres,
+                    "image_url": (artist.get("images") or [{}])[0].get("url"),
+                    "country": mb_data.get("country") or "Unknown",
+                }
+            )
         return jsonify(serialized)
     except ValueError as exc:
         return _json_error(str(exc), 400)

--- a/playlists.py
+++ b/playlists.py
@@ -8,9 +8,11 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+import pycountry
+import requests
 import spotipy
 from dotenv import load_dotenv
 from spotipy.exceptions import SpotifyException
@@ -336,8 +338,87 @@ class SpotifyDiscographyCreator:
     def search_artists(self, artist_name: str) -> List[Dict[str, Any]]:
         if not artist_name.strip():
             raise ValueError("Artist name cannot be empty")
-        results = self.sp.search(q=f"artist:{artist_name}", type="artist", limit=50)
-        return self._paginate_spotify_results(results, "items")
+        results = self.sp.search(q=f"artist:{artist_name}", type="artist", limit=12)
+        return results.get("artists", {}).get("items", [])
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _country_code_to_name(code: str) -> Optional[str]:
+        if not code:
+            return None
+        country = pycountry.countries.get(alpha_2=code.upper())
+        return country.name if country else None
+
+    @staticmethod
+    @lru_cache(maxsize=2048)
+    def _lookup_artist_metadata_cached(artist_name: str) -> Dict[str, Any]:
+        if not artist_name:
+            return {"genres": [], "country": None}
+
+        endpoint = "https://musicbrainz.org/ws/2/artist/"
+        headers = {"User-Agent": "DiscograPY/1.0 (https://github.com/based-on-what/discograpy)"}
+        params = {"query": f'artist:"{artist_name}"', "fmt": "json", "limit": 5}
+
+        try:
+            response = requests.get(endpoint, params=params, headers=headers, timeout=1.8)
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError):
+            return {"genres": [], "country": None}
+
+        candidates = payload.get("artists", []) if isinstance(payload, dict) else []
+        if not candidates:
+            return {"genres": [], "country": None}
+
+        normalized_name = artist_name.strip().casefold()
+        exact_match = next(
+            (
+                artist
+                for artist in candidates
+                if str(artist.get("name", "")).strip().casefold() == normalized_name
+            ),
+            None,
+        )
+        chosen = exact_match or max(candidates, key=lambda item: SpotifyDiscographyCreator._safe_int(item.get("score", 0)))
+
+        country_name = None
+        area = chosen.get("area")
+        if isinstance(area, dict):
+            area_name = area.get("name")
+            if area_name:
+                country_name = str(area_name)
+
+        if not country_name:
+            begin_area = chosen.get("begin-area")
+            if isinstance(begin_area, dict):
+                area_name = begin_area.get("name")
+                if area_name:
+                    country_name = str(area_name)
+
+        if not country_name:
+            country_name = SpotifyDiscographyCreator._country_code_to_name(str(chosen.get("country", "")))
+
+        raw_genres = chosen.get("genres", [])
+        if not raw_genres:
+            raw_genres = chosen.get("tags", [])
+
+        ranked_genres = sorted(
+            [genre for genre in raw_genres if isinstance(genre, dict) and genre.get("name")],
+            key=lambda genre: SpotifyDiscographyCreator._safe_int(genre.get("count", 0)),
+            reverse=True,
+        )
+        genres = [str(genre.get("name")) for genre in ranked_genres[:3]]
+
+        return {"genres": genres, "country": country_name}
+
+    def _lookup_artist_metadata(self, artist_name: str) -> Dict[str, Any]:
+        return self._lookup_artist_metadata_cached((artist_name or "").strip())
 
     def display_artists(self, artists: List[Dict[str, Any]]) -> None:
         print(f"\nFound {len(artists)} artists:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ gunicorn
 spotipy
 python-dotenv
 flask-cors
+requests
+pycountry

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,8 +16,12 @@
         --text: #e0e0e0;
         --error: #ff4d4d;
         --border: rgba(57, 255, 20, 0.35);
+        --accent-rgb: 57, 255, 20;
+        --selected-bg: rgba(57, 255, 20, 0.14);
       }
       * { box-sizing: border-box; }
+      html { color-scheme: dark; }
+      html[data-theme='light'] { color-scheme: light; }
       body {
         margin: 0;
         font-family: "Space Mono", monospace;
@@ -31,10 +35,10 @@
         border-radius: 12px;
         padding: 20px;
         margin-bottom: 18px;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.15);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.15);
       }
       .header { position: relative; }
-      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(57, 255, 20, 0.8); }
+      h1 { margin: 0 0 8px; color: var(--accent); text-shadow: 0 0 12px rgba(var(--accent-rgb), 0.8); }
       .subtitle { margin: 0 0 16px; opacity: .85; }
       .theme-toggle { position: absolute; top: 0; right: 0; }
 
@@ -47,7 +51,7 @@
         cursor: pointer;
         font-family: inherit;
         text-decoration: none;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.45);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.45);
       }
       button:disabled { opacity: .55; cursor: not-allowed; box-shadow: none; }
 
@@ -63,9 +67,38 @@
         font-family: inherit;
       }
 
-      .artists-list { max-height: 250px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
-      .artist-item { border: 1px solid var(--border); border-radius: 8px; padding: 10px; cursor: pointer; }
-      .artist-item.selected { border-color: var(--accent); box-shadow: 0 0 12px rgba(57, 255, 20, 0.5); }
+      .artists-list { max-height: 320px; overflow-y: auto; display: grid; gap: 10px; margin-top: 12px; }
+      .artist-item {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 10px;
+        cursor: pointer;
+        display: grid;
+        grid-template-columns: 56px 1fr;
+        gap: 12px;
+        align-items: center;
+      }
+      .artist-item.selected {
+        border-color: var(--accent);
+        box-shadow: 0 0 12px rgba(var(--accent-rgb), 0.5);
+        background: var(--selected-bg);
+      }
+      .artist-photo {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 1px solid var(--border);
+      }
+      .artist-photo-placeholder {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--border);
+        opacity: 0.8;
+      }
 
       .album-type-grid {
         display: grid;
@@ -83,10 +116,11 @@
       }
       .album-type-btn small { color: var(--text); opacity: 0.78; }
       .album-type-btn.selected {
-        background: rgba(57, 255, 20, 0.1);
+        background: var(--selected-bg);
         border-color: var(--accent);
-        box-shadow: 0 0 14px rgba(57, 255, 20, 0.65);
+        box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.65);
       }
+      #createBtn { margin-top: 18px; }
 
       .result-actions {
         display: flex;
@@ -101,7 +135,7 @@
         border: 1px solid var(--border);
         border-radius: 12px;
         overflow: hidden;
-        box-shadow: 0 0 10px rgba(57, 255, 20, 0.18);
+        box-shadow: 0 0 10px rgba(var(--accent-rgb), 0.18);
       }
       .embed-wrap iframe {
         width: 100%;
@@ -115,7 +149,7 @@
       .spinner {
         width: 28px;
         height: 28px;
-        border: 3px solid rgba(57, 255, 20, 0.2);
+        border: 3px solid rgba(var(--accent-rgb), 0.2);
         border-top-color: var(--accent);
         border-radius: 50%;
         animation: spin 0.8s linear infinite;
@@ -195,9 +229,28 @@
       function applyTheme(mode) {
         const dark = mode !== 'light';
         const vars = dark
-          ? { '--bg': '#0a0a0a', '--card': '#111111', '--text': '#e0e0e0' }
-          : { '--bg': '#f0f0f0', '--card': '#ffffff', '--text': '#1a1a1a' };
+          ? {
+              '--bg': '#0a0a0a',
+              '--card': '#111111',
+              '--text': '#e0e0e0',
+              '--accent': '#39ff14',
+              '--accent-2': '#00e676',
+              '--border': 'rgba(57, 255, 20, 0.35)',
+              '--accent-rgb': '57, 255, 20',
+              '--selected-bg': 'rgba(112, 255, 84, 0.34)'
+            }
+          : {
+              '--bg': '#f3f3f3',
+              '--card': '#ffffff',
+              '--text': '#ff073a',
+              '--accent': '#ff073a',
+              '--accent-2': '#ff4f72',
+              '--border': 'rgba(255, 7, 58, 0.45)',
+              '--accent-rgb': '255, 7, 58',
+              '--selected-bg': 'rgba(255, 7, 58, 0.2)'
+            };
         Object.entries(vars).forEach(([k, v]) => document.documentElement.style.setProperty(k, v));
+        document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
       }
 
       function initTheme() {
@@ -217,7 +270,13 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        const data = await res.json();
+        const raw = await res.text();
+        let data = {};
+        try {
+          data = raw ? JSON.parse(raw) : {};
+        } catch (_e) {
+          data = { error: `Server returned a non-JSON response (${res.status}).` };
+        }
         if (!res.ok) {
           const err = new Error(data.error || 'Unexpected error');
           err.data = data;
@@ -268,7 +327,16 @@
         artists.forEach((artist) => {
           const item = document.createElement('div');
           item.className = 'artist-item';
-          item.innerHTML = `<strong>${artist.name}</strong><br><span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'n/a'}</span>`;
+          const photo = artist.image_url
+            ? `<img class="artist-photo" src="${artist.image_url}" alt="Photo of ${artist.name}" loading="lazy" />`
+            : `<div class="artist-photo-placeholder">🎵</div>`;
+          item.innerHTML = `
+            ${photo}
+            <div>
+              <strong>${artist.name}</strong><br>
+              <span class="muted">Followers: ${artist.followers.toLocaleString()} · Genres: ${(artist.genres || []).join(', ') || 'not available'} · Country: ${artist.country || 'Unknown'}</span>
+            </div>
+          `;
           item.onclick = () => {
             Array.from(document.querySelectorAll('.artist-item')).forEach((n) => n.classList.remove('selected'));
             item.classList.add('selected');


### PR DESCRIPTION
### Motivation
- Provide richer and more accurate artist metadata (genres, country, image) by consulting MusicBrainz when Spotify data is sparse.
- Improve the artist search UX with photos, country display, a theme toggle, and more robust client-side parsing.
- Reduce repeated external lookups and make MusicBrainz queries resilient and performant via caching and safer network handling.

### Description
- Added a cached MusicBrainz metadata lookup (`_lookup_artist_metadata_cached`) in `playlists.py` with `requests`, `pycountry`, `lru_cache`, genre ranking, and country name resolution, plus small helpers `_safe_int` and `_country_code_to_name` and a simple `_lookup_artist_metadata` wrapper.
- Updated `search_artists` in `playlists.py` to return the flattened artist list and constrained result size returned from Spotify.
- Modified `/api/search` in `app.py` to merge MusicBrainz metadata with Spotify results, include `image_url` and `country` fields, and prefer MB genres when available.
- Improved frontend in `templates/index.html` to show artist photos/placeholders, country, refined styling and theme support, selected-item visuals, and more robust `request` JSON parsing.
- Added `requests` and `pycountry` to `requirements.txt` and imported them where needed.

### Testing
- No automated tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1733372788331a0517bad3c595cd5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Mejoras**
  * Se mejoró la información de géneros musicales para cada artista mediante búsquedas enriquecidas de metadatos adicionales.
  * El campo de país para artistas ahora muestra datos geográficos precisos en lugar de valores genéricos.
  * Mayor precisión general en los datos mostrados de artistas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->