### PR TITLE
Add track filter options and content-based filtering for playlist creation

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,6 +150,10 @@ def create_playlist():
     # Web flow always creates a playlist (dry-run disabled by product decision).
     dry_run = False
     verbose = bool(data.get("verbose", False))
+    include_live_versions = bool(data.get("include_live_versions", False))
+    include_demos = bool(data.get("include_demos", False))
+    include_remixes = bool(data.get("include_remixes", False))
+    include_instrumentals = bool(data.get("include_instrumentals", False))
 
     if not artist_id or not artist_name:
         return _json_error("artist_id and artist_name are required", 400)
@@ -177,7 +181,14 @@ def create_playlist():
         )
         playlist_name = f"{artist_name} discography {suffix}"
 
-        track_uris = creator._collect_tracks_from_albums(filtered_albums, verbose=verbose)
+        track_uris = creator._collect_tracks_from_albums(
+            filtered_albums,
+            verbose=verbose,
+            include_live_versions=include_live_versions,
+            include_demos=include_demos,
+            include_remixes=include_remixes,
+            include_instrumentals=include_instrumentals,
+        )
         if not track_uris:
             return _json_error("No tracks found for selected albums", 404)
 

--- a/playlists.py
+++ b/playlists.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -451,8 +452,75 @@ class SpotifyDiscographyCreator:
         results = self.sp.album_tracks(album_id=album_id, limit=50)
         return self._paginate_spotify_results(results, "items")
 
-    def _collect_tracks_from_albums(self, albums: List[Dict[str, Any]], verbose: bool = False) -> List[str]:
+    @staticmethod
+    def _title_has_live_marker(text: str) -> bool:
+        return bool(re.search(r"\b(live|en vivo|acoustic live)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_demo_marker(text: str) -> bool:
+        return bool(re.search(r"\b(demo|rough mix|work tape|unreleased demo)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_remix_marker(text: str) -> bool:
+        return bool(re.search(r"\b(remix|rework|edit|extended mix|club mix|dub mix)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_instrumental_marker(text: str) -> bool:
+        return bool(re.search(r"\b(instrumental)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _normalize_title_for_comparison(text: str) -> str:
+        normalized = text.lower()
+        normalized = re.sub(r"[\[\(].*?[\]\)]", " ", normalized)
+        normalized = re.sub(
+            r"\b(live|en vivo|acoustic live|demo|rough mix|work tape|unreleased demo|remix|rework|edit|extended mix|club mix|dub mix|instrumental)\b",
+            " ",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+        return " ".join(normalized.split())
+
+    def _track_passes_content_filters(
+        self,
+        track_name: str,
+        album_name: str,
+        include_live_versions: bool,
+        include_demos: bool,
+        include_remixes: bool,
+        include_instrumentals: bool,
+        included_non_instrumental_bases: Set[str],
+    ) -> bool:
+        searchable = f"{track_name} {album_name}"
+        normalized_base = self._normalize_title_for_comparison(track_name)
+
+        if not include_live_versions and self._title_has_live_marker(searchable):
+            return False
+        if not include_demos and self._title_has_demo_marker(searchable):
+            return False
+        if not include_remixes and self._title_has_remix_marker(searchable):
+            return False
+        if self._title_has_instrumental_marker(searchable):
+            if not include_instrumentals:
+                return False
+            if normalized_base and normalized_base not in included_non_instrumental_bases:
+                return False
+            return True
+        if normalized_base:
+            included_non_instrumental_bases.add(normalized_base)
+        return True
+
+    def _collect_tracks_from_albums(
+        self,
+        albums: List[Dict[str, Any]],
+        verbose: bool = False,
+        include_live_versions: bool = False,
+        include_demos: bool = False,
+        include_remixes: bool = False,
+        include_instrumentals: bool = False,
+    ) -> List[str]:
         all_track_uris: List[str] = []
+        included_non_instrumental_bases: Set[str] = set()
         with ThreadPoolExecutor(max_workers=5) as executor:
             future_map = {
                 executor.submit(self._get_album_tracks, album["id"]): album
@@ -469,9 +537,37 @@ class SpotifyDiscographyCreator:
             ordered_results.sort(key=lambda item: item[0])
 
             for _, album_name, tracks in ordered_results:
-                track_uris = [track["uri"] for track in tracks if track.get("uri")]
+                track_uris: List[str] = []
+                skipped_tracks = 0
+                sorted_tracks = sorted(
+                    tracks,
+                    key=lambda item: (self._safe_int(item.get("disc_number", 1)), self._safe_int(item.get("track_number", 0))),
+                )
+                for track in sorted_tracks:
+                    uri = track.get("uri")
+                    track_name = str(track.get("name", ""))
+                    if not uri:
+                        continue
+                    if not self._track_passes_content_filters(
+                        track_name=track_name,
+                        album_name=album_name,
+                        include_live_versions=include_live_versions,
+                        include_demos=include_demos,
+                        include_remixes=include_remixes,
+                        include_instrumentals=include_instrumentals,
+                        included_non_instrumental_bases=included_non_instrumental_bases,
+                    ):
+                        skipped_tracks += 1
+                        continue
+                    track_uris.append(uri)
+
                 all_track_uris.extend(track_uris)
-                self.logger.info("Processed album: %s (%s tracks)", album_name, len(track_uris))
+                self.logger.info(
+                    "Processed album: %s (%s kept, %s filtered)",
+                    album_name,
+                    len(track_uris),
+                    skipped_tracks,
+                )
 
         return all_track_uris
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,20 @@
         border-color: var(--accent);
         box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.65);
       }
+      .filter-options {
+        margin-top: 16px;
+        display: grid;
+        gap: 10px;
+      }
+      .filter-option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .filter-option input[type="checkbox"] {
+        width: auto;
+        margin: 0;
+      }
       #createBtn { margin-top: 18px; }
 
       .result-actions {
@@ -186,6 +200,26 @@
 
         <h3>Playlist type</h3>
         <div id="albumTypeButtons" class="album-type-grid"></div>
+
+        <h3>Track filters</h3>
+        <div class="filter-options">
+          <label class="filter-option" for="includeLive">
+            <input id="includeLive" type="checkbox" />
+            <span>¿Incluir versiones en vivo?</span>
+          </label>
+          <label class="filter-option" for="includeDemos">
+            <input id="includeDemos" type="checkbox" />
+            <span>¿Incluir demos?</span>
+          </label>
+          <label class="filter-option" for="includeRemixes">
+            <input id="includeRemixes" type="checkbox" />
+            <span>¿Incluir remixes?</span>
+          </label>
+          <label class="filter-option" for="includeInstrumentals">
+            <input id="includeInstrumentals" type="checkbox" />
+            <span>¿Incluir versiones instrumentales?</span>
+          </label>
+        </div>
 
         <button id="createBtn">Create playlist</button>
         <div id="createLoading" class="loading hidden"><div class="spinner"></div><span>Creating your discography playlist…</span></div>
@@ -399,6 +433,10 @@
           artist_id: state.selectedArtist.id,
           artist_name: state.selectedArtist.name,
           album_type_selection: Number(state.selectedAlbumType),
+          include_live_versions: el('includeLive').checked,
+          include_demos: el('includeDemos').checked,
+          include_remixes: el('includeRemixes').checked,
+          include_instrumentals: el('includeInstrumentals').checked,
           dry_run: false,
           verbose: false
         };
@@ -436,6 +474,10 @@
         el('artistsList').innerHTML = '';
         el('searchError').textContent = '';
         el('createError').textContent = '';
+        el('includeLive').checked = false;
+        el('includeDemos').checked = false;
+        el('includeRemixes').checked = false;
+        el('includeInstrumentals').checked = false;
         setSearchLoading(false);
         setCreateLoading(false);
         el('playlistEmbedWrap').classList.add('hidden');


### PR DESCRIPTION
### Motivation

- Allow users to exclude or include live versions, demos, remixes, and instrumental tracks when generating discography playlists.
- Prevent unwanted variants (e.g. live/remix/demo) from inflating or polluting generated playlists and ensure instrumentals are only included when the non-instrumental base is present.

### Description

- Added UI checkboxes for track filters in `templates/index.html` and wired them into the create payload sent to `/api/create`.
- Read `include_live_versions`, `include_demos`, `include_remixes`, and `include_instrumentals` flags in `app.py` and pass them to `SpotifyDiscographyCreator._collect_tracks_from_albums`.
- Implemented regex-based detection helpers and a `_track_passes_content_filters` helper in `playlists.py`, added title normalization, sorted tracks by disc/track number, and updated `_collect_tracks_from_albums` to filter tracks according to the selected options while tracking and logging filtered counts.
- Added `re` import and small typing/logging improvements to support the new behavior.

### Testing

- Ran the test suite with `pytest -q` and all tests completed successfully.
- Confirmed no new linter errors were introduced by the changes when running the repository's automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d86b29e48331aaad9ffe345685dd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versión

* **Nuevas Funcionalidades**
  * Se han añadido filtros de pistas para versiones en vivo, demos, remixes e instrumentales.
  * Nuevo panel de opciones de filtrado en la interfaz de usuario que permite seleccionar qué tipos de pistas incluir en la reproducción.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->