### PR TITLE
Add track filter options, deduplication and artist-image playlist cover upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,6 +150,12 @@ def create_playlist():
     # Web flow always creates a playlist (dry-run disabled by product decision).
     dry_run = False
     verbose = bool(data.get("verbose", False))
+    include_live_versions = bool(data.get("include_live_versions", False))
+    include_demos = bool(data.get("include_demos", False))
+    include_remixes = bool(data.get("include_remixes", False))
+    include_instrumentals = bool(data.get("include_instrumentals", False))
+    include_duplicate_versions = bool(data.get("include_duplicate_versions", False))
+    use_artist_image_as_cover = bool(data.get("use_artist_image_as_cover", False))
 
     if not artist_id or not artist_name:
         return _json_error("artist_id and artist_name are required", 400)
@@ -177,18 +183,29 @@ def create_playlist():
         )
         playlist_name = f"{artist_name} discography {suffix}"
 
-        track_uris = creator._collect_tracks_from_albums(filtered_albums, verbose=verbose)
+        track_uris = creator._collect_tracks_from_albums(
+            filtered_albums,
+            verbose=verbose,
+            include_live_versions=include_live_versions,
+            include_demos=include_demos,
+            include_remixes=include_remixes,
+            include_instrumentals=include_instrumentals,
+            include_duplicate_versions=include_duplicate_versions,
+        )
         if not track_uris:
             return _json_error("No tracks found for selected albums", 404)
 
         playlist_id = None
         playlist_url = None
+        cover_applied = False
 
         if not dry_run:
             playlist = creator._create_playlist(playlist_name, creator.PLAYLIST_DESCRIPTION)
             playlist_id = playlist.get("id")
             if playlist_id:
                 creator._add_tracks_to_playlist(playlist_id, track_uris)
+                if use_artist_image_as_cover:
+                    cover_applied = creator._set_playlist_cover_from_artist(playlist_id=playlist_id, artist_id=artist_id)
                 playlist_url = f"https://open.spotify.com/playlist/{playlist_id}"
 
         response = {
@@ -198,6 +215,7 @@ def create_playlist():
             "playlist_url": playlist_url,
             "albums_included": len(filtered_albums),
             "tracks_added": len(track_uris),
+            "cover_applied": cover_applied,
             "dry_run": dry_run,
         }
         return jsonify(response)

--- a/playlists.py
+++ b/playlists.py
@@ -1,8 +1,10 @@
 """DiscograPY CLI for creating Spotify discography playlists."""
 
 import argparse
+import base64
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -169,7 +171,7 @@ class SpotifyDiscographyCreator:
             raise EnvironmentError(f"Missing required environment variables: {', '.join(missing)}")
 
         # Keep both public and private playlist scopes for future flexibility.
-        scope = "playlist-modify-public playlist-modify-private"
+        scope = "playlist-modify-public playlist-modify-private ugc-image-upload"
         auth = SpotifyOAuth(
             client_id=client_id,
             client_secret=client_secret,
@@ -451,8 +453,85 @@ class SpotifyDiscographyCreator:
         results = self.sp.album_tracks(album_id=album_id, limit=50)
         return self._paginate_spotify_results(results, "items")
 
-    def _collect_tracks_from_albums(self, albums: List[Dict[str, Any]], verbose: bool = False) -> List[str]:
-        all_track_uris: List[str] = []
+    @staticmethod
+    def _title_has_live_marker(text: str) -> bool:
+        return bool(re.search(r"\b(live|en vivo|acoustic live)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_demo_marker(text: str) -> bool:
+        return bool(re.search(r"\b(demo|rough mix|work tape|unreleased demo)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_remix_marker(text: str) -> bool:
+        return bool(re.search(r"\b(remix|rework|edit|extended mix|club mix|dub mix)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _title_has_instrumental_marker(text: str) -> bool:
+        return bool(re.search(r"\b(instrumental)\b", text, flags=re.IGNORECASE))
+
+    @staticmethod
+    def _normalize_title_for_comparison(text: str) -> str:
+        normalized = text.lower()
+        normalized = re.sub(r"[\[\(].*?[\]\)]", " ", normalized)
+        normalized = re.sub(
+            r"\b(live|en vivo|acoustic live|demo|rough mix|work tape|unreleased demo|remix|rework|edit|extended mix|club mix|dub mix|instrumental)\b",
+            " ",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+        return " ".join(normalized.split())
+
+    def _album_release_priority(self, album: Dict[str, Any]) -> int:
+        album_type = str(album.get("album_type", "")).lower()
+        if album_type == "album":
+            return 3
+        if self._is_ep(album):
+            return 2
+        if self._is_single(album):
+            return 1
+        return 0
+
+    def _track_passes_content_filters(
+        self,
+        track_name: str,
+        album_name: str,
+        include_live_versions: bool,
+        include_demos: bool,
+        include_remixes: bool,
+        include_instrumentals: bool,
+        included_non_instrumental_bases: Set[str],
+    ) -> bool:
+        searchable = f"{track_name} {album_name}"
+        normalized_base = self._normalize_title_for_comparison(track_name)
+
+        if not include_live_versions and self._title_has_live_marker(searchable):
+            return False
+        if not include_demos and self._title_has_demo_marker(searchable):
+            return False
+        if not include_remixes and self._title_has_remix_marker(searchable):
+            return False
+        if self._title_has_instrumental_marker(searchable):
+            if not include_instrumentals:
+                return False
+            if normalized_base and normalized_base not in included_non_instrumental_bases:
+                return False
+            return True
+        if normalized_base:
+            included_non_instrumental_bases.add(normalized_base)
+        return True
+
+    def _collect_tracks_from_albums(
+        self,
+        albums: List[Dict[str, Any]],
+        verbose: bool = False,
+        include_live_versions: bool = False,
+        include_demos: bool = False,
+        include_remixes: bool = False,
+        include_instrumentals: bool = False,
+        include_duplicate_versions: bool = False,
+    ) -> List[str]:
+        included_non_instrumental_bases: Set[str] = set()
         with ThreadPoolExecutor(max_workers=5) as executor:
             future_map = {
                 executor.submit(self._get_album_tracks, album["id"]): album
@@ -460,20 +539,67 @@ class SpotifyDiscographyCreator:
                 if album.get("id")
             }
 
-            ordered_results: List[Tuple[str, str, List[Dict[str, Any]]]] = []
+            ordered_results: List[Tuple[str, Dict[str, Any], str, List[Dict[str, Any]]]] = []
             for future in as_completed(future_map):
                 album = future_map[future]
                 tracks = future.result()
-                ordered_results.append((album.get("release_date", ""), album.get("name", "Unknown"), tracks))
+                ordered_results.append((album.get("release_date", ""), album, album.get("name", "Unknown"), tracks))
 
             ordered_results.sort(key=lambda item: item[0])
 
-            for _, album_name, tracks in ordered_results:
-                track_uris = [track["uri"] for track in tracks if track.get("uri")]
-                all_track_uris.extend(track_uris)
-                self.logger.info("Processed album: %s (%s tracks)", album_name, len(track_uris))
+            track_candidates: List[Tuple[str, str, int, int]] = []
+            order_index = 0
 
-        return all_track_uris
+            for _, album, album_name, tracks in ordered_results:
+                track_uris: List[str] = []
+                skipped_tracks = 0
+                sorted_tracks = sorted(
+                    tracks,
+                    key=lambda item: (self._safe_int(item.get("disc_number", 1)), self._safe_int(item.get("track_number", 0))),
+                )
+                for track in sorted_tracks:
+                    uri = track.get("uri")
+                    track_name = str(track.get("name", ""))
+                    if not uri:
+                        continue
+                    if not self._track_passes_content_filters(
+                        track_name=track_name,
+                        album_name=album_name,
+                        include_live_versions=include_live_versions,
+                        include_demos=include_demos,
+                        include_remixes=include_remixes,
+                        include_instrumentals=include_instrumentals,
+                        included_non_instrumental_bases=included_non_instrumental_bases,
+                    ):
+                        skipped_tracks += 1
+                        continue
+                    track_uris.append(uri)
+                    normalized_base = self._normalize_title_for_comparison(track_name) or track_name.strip().lower()
+                    track_candidates.append((normalized_base, uri, self._album_release_priority(album), order_index))
+                    order_index += 1
+
+                self.logger.info(
+                    "Processed album: %s (%s kept, %s filtered)",
+                    album_name,
+                    len(track_uris),
+                    skipped_tracks,
+                )
+
+        if include_duplicate_versions:
+            return [uri for _, uri, _, _ in track_candidates]
+
+        best_by_track: Dict[str, Tuple[str, int, int]] = {}
+        for normalized_base, uri, priority, appearance_order in track_candidates:
+            existing = best_by_track.get(normalized_base)
+            if existing is None:
+                best_by_track[normalized_base] = (uri, priority, appearance_order)
+                continue
+            _, existing_priority, _ = existing
+            if priority > existing_priority:
+                best_by_track[normalized_base] = (uri, priority, appearance_order)
+
+        deduped = sorted(best_by_track.values(), key=lambda item: item[2])
+        return [uri for uri, _, _ in deduped]
 
     @retry_on_failure(max_retries=3)
     def _create_playlist(self, playlist_name: str, description: str) -> Dict[str, Any]:
@@ -490,6 +616,44 @@ class SpotifyDiscographyCreator:
         for start in range(0, len(track_uris), batch_size):
             batch = track_uris[start : start + batch_size]
             self.sp.playlist_add_items(playlist_id=playlist_id, items=batch)
+
+    @retry_on_failure(max_retries=3)
+    def _get_artist(self, artist_id: str) -> Dict[str, Any]:
+        return self.sp.artist(artist_id)
+
+    @retry_on_failure(max_retries=3)
+    def _upload_playlist_cover(self, playlist_id: str, image_b64: str) -> None:
+        self.sp.playlist_upload_cover_image(playlist_id, image_b64)
+
+    def _set_playlist_cover_from_artist(self, playlist_id: str, artist_id: str) -> bool:
+        try:
+            artist = self._get_artist(artist_id)
+            images = artist.get("images", []) if isinstance(artist, dict) else []
+            if not images:
+                self.logger.warning("Artist has no Spotify images; skipping playlist cover upload.")
+                return False
+
+            # Try smaller images first to improve odds of meeting Spotify size limits.
+            sorted_images = sorted(images, key=lambda img: self._safe_int(img.get("height")))
+            for image in sorted_images:
+                image_url = image.get("url")
+                if not image_url:
+                    continue
+                response = requests.get(image_url, timeout=5)
+                response.raise_for_status()
+                if len(response.content) > 256_000:
+                    continue
+
+                encoded = base64.b64encode(response.content).decode("ascii")
+                self._upload_playlist_cover(playlist_id, encoded)
+                self.logger.info("Playlist cover uploaded from artist image: %s", image_url)
+                return True
+        except (requests.RequestException, SpotifyException, ValueError) as exc:
+            self.logger.warning("Failed to set playlist cover from artist image: %s", exc)
+            return False
+
+        self.logger.warning("Could not upload artist image as playlist cover (size/availability constraints).")
+        return False
 
     def _spotify_error_message(self, exc: SpotifyException) -> str:
         messages = {

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,20 @@
         border-color: var(--accent);
         box-shadow: 0 0 14px rgba(var(--accent-rgb), 0.65);
       }
+      .filter-options {
+        margin-top: 16px;
+        display: grid;
+        gap: 10px;
+      }
+      .filter-option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .filter-option input[type="checkbox"] {
+        width: auto;
+        margin: 0;
+      }
       #createBtn { margin-top: 18px; }
 
       .result-actions {
@@ -186,6 +200,38 @@
 
         <h3>Playlist type</h3>
         <div id="albumTypeButtons" class="album-type-grid"></div>
+
+        <h3>Track filters</h3>
+        <div class="filter-options">
+          <label class="filter-option" for="includeLive">
+            <input id="includeLive" type="checkbox" />
+            <span>Include live versions</span>
+          </label>
+          <label class="filter-option" for="includeDemos">
+            <input id="includeDemos" type="checkbox" />
+            <span>Include demos</span>
+          </label>
+          <label class="filter-option" for="includeRemixes">
+            <input id="includeRemixes" type="checkbox" />
+            <span>Include remixes</span>
+          </label>
+          <label class="filter-option" for="includeInstrumentals">
+            <input id="includeInstrumentals" type="checkbox" />
+            <span>Include instrumental versions</span>
+          </label>
+          <label class="filter-option" for="includeDuplicateVersions">
+            <input id="includeDuplicateVersions" type="checkbox" />
+            <span>Include duplicate track versions</span>
+          </label>
+        </div>
+
+        <h3>Playlist cover</h3>
+        <div class="filter-options">
+          <label class="filter-option" for="useArtistImageAsCover">
+            <input id="useArtistImageAsCover" type="checkbox" />
+            <span>Use official Spotify artist photo as playlist cover</span>
+          </label>
+        </div>
 
         <button id="createBtn">Create playlist</button>
         <div id="createLoading" class="loading hidden"><div class="spinner"></div><span>Creating your discography playlist…</span></div>
@@ -399,6 +445,12 @@
           artist_id: state.selectedArtist.id,
           artist_name: state.selectedArtist.name,
           album_type_selection: Number(state.selectedAlbumType),
+          include_live_versions: el('includeLive').checked,
+          include_demos: el('includeDemos').checked,
+          include_remixes: el('includeRemixes').checked,
+          include_instrumentals: el('includeInstrumentals').checked,
+          include_duplicate_versions: el('includeDuplicateVersions').checked,
+          use_artist_image_as_cover: el('useArtistImageAsCover').checked,
           dry_run: false,
           verbose: false
         };
@@ -436,6 +488,12 @@
         el('artistsList').innerHTML = '';
         el('searchError').textContent = '';
         el('createError').textContent = '';
+        el('includeLive').checked = false;
+        el('includeDemos').checked = false;
+        el('includeRemixes').checked = false;
+        el('includeInstrumentals').checked = false;
+        el('includeDuplicateVersions').checked = false;
+        el('useArtistImageAsCover').checked = false;
         setSearchLoading(false);
         setCreateLoading(false);
         el('playlistEmbedWrap').classList.add('hidden');


### PR DESCRIPTION
### Motivation
- Provide users control over which variant tracks are included by adding filters for live versions, demos, remixes, instrumental versions, and duplicate-version inclusion.  
- Improve playlist quality by preferring canonical releases when multiple versions of the same track exist.  
- Allow using the artist's Spotify image as the playlist cover to give generated playlists a nicer presentation.

### Description
- Wire new boolean options through the web UI and API: `include_live_versions`, `include_demos`, `include_remixes`, `include_instrumentals`, `include_duplicate_versions`, and `use_artist_image_as_cover` (front-end changes in `templates/index.html` and parameter handling in `app.py`).
- Extend `SpotifyDiscographyCreator._collect_tracks_from_albums` to filter tracks using regex-based content detectors, normalize titles for deduplication, and select the best release per track based on release type priority, while keeping optional `include_duplicate_versions` behavior.  
- Add helper methods for title normalization and marker detection, album release priority logic, and safe ordering preservation, and change concurrency handling to collect and rank track candidates before finalizing URIs.  
- Add playlist cover upload support with Spotify `ugc-image-upload` scope and helper methods `_get_artist`, `_upload_playlist_cover`, and `_set_playlist_cover_from_artist` that fetch, size-check, base64-encode, and upload an artist image; `app.py` now attempts to apply the cover and returns a `cover_applied` flag.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d86b29e48331aaad9ffe345685dd)